### PR TITLE
Fix unintended autoplay start when controller is used

### DIFF
--- a/lib/src/swiper.dart
+++ b/lib/src/swiper.dart
@@ -355,7 +355,7 @@ abstract class _SwiperTimerMixin extends State<Swiper> {
         _stopAutoplay();
       }
     } else if (event is IndexControllerEventBase) {
-      if (event.needToResetTimer) {
+      if (event.needToResetTimer && (widget.autoplay || _timer != null)) {
         _startAutoplay();
       }
     }
@@ -521,8 +521,7 @@ class _SwiperState extends _SwiperTimerMixin {
       //default
       var transformer = widget.transformer;
       if (widget.scale != null || widget.fade != null) {
-        transformer =
-            ScaleAndFadeTransformer(scale: widget.scale, fade: widget.fade);
+        transformer = ScaleAndFadeTransformer(scale: widget.scale, fade: widget.fade);
       }
 
       final child = TransformerPageView(
@@ -656,10 +655,8 @@ class _SwiperState extends _SwiperTimerMixin {
     if (widget.pagination != null) {
       config = _ensureConfig(config);
       if (widget.outer) {
-        return _buildOuterPagination(
-            widget.pagination! as SwiperPagination,
-            listForStack == null ? swiper : Stack(children: listForStack),
-            config);
+        return _buildOuterPagination(widget.pagination! as SwiperPagination,
+            listForStack == null ? swiper : Stack(children: listForStack), config);
       } else {
         listForStack = _ensureListForStack(
           swiper: swiper,
@@ -881,9 +878,8 @@ class _TinderState extends _CustomLayoutStateBase<_TinderSwiper> {
     final o = _getValue(opacity, animationValue, i);
     final a = _getValue(rotates, animationValue, i);
 
-    final alignment = widget.scrollDirection == Axis.horizontal
-        ? Alignment.bottomCenter
-        : Alignment.centerLeft;
+    final alignment =
+        widget.scrollDirection == Axis.horizontal ? Alignment.bottomCenter : Alignment.centerLeft;
 
     return Opacity(
       opacity: o,
@@ -940,10 +936,8 @@ class _StackViewState extends _CustomLayoutStateBase<_StackSwiper> {
 
     //Array below this line, '0' index is 1.0, which is the first item show in swiper.
     _startIndex = isRightSide ? -1 : -3;
-    scales =
-        isRightSide ? [1.0, 1.0, 0.9, 0.8, 0.7] : [0.7, 0.8, 0.9, 1.0, 1.0];
-    opacity =
-        isRightSide ? [1.0, 1.0, 1.0, 0.5, 0.0] : [0.0, 0.5, 1.0, 1.0, 1.0];
+    scales = isRightSide ? [1.0, 1.0, 0.9, 0.8, 0.7] : [0.7, 0.8, 0.9, 1.0, 1.0];
+    opacity = isRightSide ? [1.0, 1.0, 1.0, 0.5, 0.0] : [0.0, 0.5, 1.0, 1.0, 1.0];
 
     _updateValues();
   }

--- a/test/autoplay_logic_test.dart
+++ b/test/autoplay_logic_test.dart
@@ -1,0 +1,50 @@
+import 'package:card_swiper/card_swiper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Autoplay stays false after next() if autoplay is disabled', (tester) async {
+    final controller = SwiperController();
+    int currentIndex = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: Swiper(
+        controller: controller,
+        autoplay: false,
+        autoplayDelay: 100, // Short delay for testing
+        itemBuilder: (context, index) {
+          return Text('$index');
+        },
+        itemCount: 10,
+        onIndexChanged: (index) {
+          currentIndex = index;
+        },
+      ),
+    ));
+
+    expect(find.text('0'), findsOneWidget);
+    expect(currentIndex, 0);
+
+    // Initial wait to ensure no autoplay starts
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(currentIndex, 0);
+
+    // Trigger next
+    // The controller.next() calls the internal logic.
+    // We need to await the Future returned by next() if possible,
+    // or just pump enough time for animation.
+    controller.next();
+    await tester.pumpAndSettle();
+
+    expect(currentIndex, 1);
+    expect(find.text('1'), findsOneWidget);
+
+    // Wait for potential autoplay delay (100ms set in widget)
+    // If the bug exists, this will trigger another move to index 2
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle(); // Allow animation to complete if it triggered
+
+    // Should still be at 1
+    expect(currentIndex, 1);
+    expect(find.text('1'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Autoplay starts when using a controller after the next call. It calls _startAutoPlay without the autoplay flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autoplay handling to prevent unintended restarts when autoplay is disabled, ensuring manual navigation does not trigger automatic playback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->